### PR TITLE
Task/12834: Configure compose file to serve db and api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/.env.example.local
+++ b/.env.example.local
@@ -1,0 +1,2 @@
+MONGO_URI=mongodb://root:example@localhost:27017/
+NODE_ENV=development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:16-bullseye
+
+WORKDIR /usr/app
+COPY package.json .
+RUN npm i --quiet
+RUN npm i --location=global nodemon
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM node:16-bullseye
 
 WORKDIR /usr/app
 COPY package.json .
-RUN npm i --quiet
+COPY yarn.lock .
 RUN npm i --location=global nodemon
+RUN yarn
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This option is useful when you are making changes to the API
 * Copy the contents of `env.example.local` to a new file called `.env`. The contents of `.env.example.local` are pre-configured to connect to the database created by `compose.yaml`
   - `cat .env.example.local > .env` (or manually create the file, then copy and paste)
 * Start the api server by running
-  - `yarn run devstart`
+  - `yarn run dev`
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,45 @@
 # Applicant Maps API
 
-An Express API for creating, reading, and updating DCP Applicant Maps.  Uses a mongodb database to store documents for an applicant mapping project.
+An Express API for creating, reading, and updating DCP Applicant Maps. It uses mongodb to store documents for an applicant mapping project.
 
 Works with the [labs-applicantmaps](https://github.com/nycplanning/labs-applicantmaps) frontend app.
+
+## Setting Up a Local Development Environment
+
+### Requirements
+
+You will need the following things installed on your computer.
+
+- [Git](https://git-scm.com/)
+- [Node.js](https://nodejs.org/) **version listed in .nvmrc**
+  - We suggest installing versions of Node via [nvm](https://github.com/nvm-sh/nvm).
+- [Yarn v1.x](https://classic.yarnpkg.com/lang/en/)
+- [Nodemon](https://nodemon.io/)
+- [Docker](https://www.docker.com/get-started/)
+- [Docker compose v2](https://docs.docker.com/compose/compose-file/)
+  - Compose is available as a CLI plugin or through a setting in Docker Desktop
+
+### Option 1: MongoDB and Node API in docker network
+This option is useful when you are working on the frontend and simply want to run a local backend
+
+* Run all services in the compose file, which includes the database and api
+  - `docker compose up` 
+
+### Option 2: MongoDB in docker and Node API on host
+This option is useful when you are making changes to the API
+
+* Run MongoDB in docker
+  - `docker compose up mongo`
+* Install the [listed](.nvmrc) version of Node
+  - (If using nvm) `nvm install`
+* Install Yarn and Nodemon
+  - `npm i --location=global yarn nodemon`
+* Install Dependencies using Yarn
+  - `yarn`
+* Copy the contents of `env.example.local` to a new file called `.env`. The contents of `.env.example.local` are pre-configured to connect to the database created by `compose.yaml`
+  - `cat .env.example.local > .env` (or manually create the file, then copy and paste)
+* Start the api server by running
+  - `yarn run devstart`
 
 ## Endpoints
 
@@ -16,7 +53,7 @@ Works with the [labs-applicantmaps](https://github.com/nycplanning/labs-applican
 - Update an existing project by id.  This results in incrementing the `__v` attribute in mongodb.
 
 ## Environment Variables
-Create a `.env` file based on `.env-sample`.
+When deploying, create a `.env` file based on `.env.example`.
 
 `MONGO_URI` - the connection string for the mongodb database
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
       - db:/data/db
   api:
     build: .
-    command: npm run devstart
+    command: yarn run devstart
     ports:
       - 3000:3000
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,21 @@
+services:
+  mongo:
+    image: mongo:6.0.5-jammy
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    ports:
+      - 27017:27017
+    volumes:
+      - db:/data/db
+  api:
+    build: .
+    command: npm run devstart
+    ports:
+      - 3000:3000
+    depends_on:
+      - mongo
+    environment:
+      MONGO_URI: mongodb://root:example@mongo:27017/
+volumes:
+  db:

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
       - db:/data/db
   api:
     build: .
-    command: yarn run devstart
+    command: yarn run dev
     ports:
       - 3000:3000
     depends_on:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "devstart": "nodemon ./bin/www",
+    "dev": "nodemon ./bin/www",
     "test": "NODE_ENV=test node ./node_modules/mocha/bin/mocha ./test/**/*.js --exit"
   },
   "dependencies": {


### PR DESCRIPTION
In support of the upgrades for [lab-applicantmaps](https://github.com/NYCPlanning/labs-applicantmaps), I wanted to run the frontend against a local instance of the backend. There did not seem to be a simple way to run a local and disposable instance of the database. Additionally, configuring and running the api separately felt cumbersome. 

These changes dockerize the db and api. They also provide instructions in the readme on how to run either the DB only or the DB and API together through the Docker Compose. Assuming future developers have docker compose pre-configured, this should make backend setup a one-step process, making it easier to focus on frontend work.

Supports [AB#12834](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/12834) 